### PR TITLE
Add HOSTCFLAGS compile arguments for utility compilation

### DIFF
--- a/scripts/fips_kaslr_crypto_hmac.sh
+++ b/scripts/fips_kaslr_crypto_hmac.sh
@@ -253,7 +253,7 @@ fi
 
 #start patching vmlinux with static patcher, temporary put it here 
 rm -f kaslr_fips
-$HOSTCC -o kaslr_fips  $srctree/scripts/kaslr_fips.c
+$HOSTCC $HOSTCFLAGS -o kaslr_fips  $srctree/scripts/kaslr_fips.c
 retval=$?
 if [ $retval -ne 0 ]; then
 	echo "$0 : $HOSTCC returned error"
@@ -261,7 +261,7 @@ if [ $retval -ne 0 ]; then
 fi
 
 rm -f fips_crypto_utils
-$HOSTCC -o fips_crypto_utils $srctree/scripts/fips_crypto_utils.c
+$HOSTCC $HOSTCFLAGS -o fips_crypto_utils $srctree/scripts/fips_crypto_utils.c
 retval=$?
 if [ $retval -ne 0 ]; then
 	echo "$0 : $HOSTCC returned error"
@@ -269,7 +269,7 @@ if [ $retval -ne 0 ]; then
 fi
 
 rm -f fips_fmp_utils
-$HOSTCC -o fips_fmp_utils $srctree/scripts/fips_fmp_utils.c
+$HOSTCC $HOSTCFLAGS -o fips_fmp_utils $srctree/scripts/fips_fmp_utils.c
 retval=$?
 if [ $retval -ne 0 ]; then
 	echo "$0 : $HOSTCC returned error"


### PR DESCRIPTION
I have experience compilation erros when using this [docker image](https://github.com/lineageos4microg/docker-lineage-cicd/)
There was also an independent user with the same experience: https://github.com/lineageos4microg/docker-lineage-cicd/issues/139#issuecomment-792261251
The error message is
`clang-11: error: unable to execute command: Executable "ld" doesn't exist!`
and comes right after the stdout `FIPS with KALSR : Generating hmac of crypto and fmp, then update vmlinux...`

I did not track down where the HOSTC flags etc. are set and where the PATH variable is changed to not include ld.
However, with trial and error I have found out that this patch seems to work as the linker is set to lld in the HOSTCFLAGS.
I guess these changes should not affect different build environments, at least I hope so :)

Thanks in advance!